### PR TITLE
Update angular version to ^2.4.9 and add @types/vis (fixes AOT)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,24 +50,25 @@
     "postversion": "git push origin master && git push --tags"
   },
   "dependencies": {
+    "@types/vis": "^4.17.4",
     "vis": "^4.17.0"
   },
   "peerDependencies": {
-    "@angular/common": "^2.3.0",
-    "@angular/core": "^2.3.0",
-    "@angular/compiler": "^2.3.0",
-    "@angular/forms": "^2.3.0",
+    "@angular/common": "^2.4.9",
+    "@angular/core": "^2.4.9",
+    "@angular/compiler": "^2.4.9",
+    "@angular/forms": "^2.4.9",
     "@angular/router": "^3.3.0"
   },
   "devDependencies": {
-    "@angular/common": "^2.3.0",
-    "@angular/compiler": "^2.3.0",
-    "@angular/compiler-cli": "^2.3.0",
-    "@angular/core": "^2.3.0",
-    "@angular/forms": "^2.3.0",
-    "@angular/platform-browser": "^2.3.0",
-    "@angular/platform-browser-dynamic": "^2.3.0",
-    "@angular/platform-server": "^2.3.0",
+    "@angular/common": "^2.4.9",
+    "@angular/compiler": "^2.4.9",
+    "@angular/compiler-cli": "^2.4.9",
+    "@angular/core": "^2.4.9",
+    "@angular/forms": "^2.4.9",
+    "@angular/platform-browser": "^2.4.9",
+    "@angular/platform-browser-dynamic": "^2.4.9",
+    "@angular/platform-server": "^2.4.9",
     "@angular/router": "^3.3.0",
     "@types/jasmine": "^2.5.38",
     "@types/node": "6.0.45",


### PR DESCRIPTION
This fix unblocks compiling an angular cli app and resolves #26 (for me anyways).

When I ran `git commit` I got a whole pile of lint errors regarding different ts files, but the only file I modified was `package.json` so I'm not sure why. I bypassed them, but I'm guessing the tests will fail on travis too.

Please merge this or give me a timeline as to when you can make this change. This is blocking me using this plugin in my app entirely.