### PR TITLE
Update package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "vis": "4.17.0",
-    "@types/vis": "4.17.4"
+    "@types/vis": "^4.17.4"
   },
   "peerDependencies": {
     "@angular/common": "^2.4.10",


### PR DESCRIPTION
rollingMode should be optional in VisTimelineOptions, which is the case in v4.18.3